### PR TITLE
Fixes #77

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ sodiumoxide = "0.0.4"
 time = "0.1.25"
 rand = "*"
 self_encryption = "0.1.3"
+
+[features]
+USE_ACTUAL_ROUTING = []

--- a/examples/rest_api.rs
+++ b/examples/rest_api.rs
@@ -48,13 +48,10 @@ fn create_account() -> Result<maidsafe_client::client::Client, String> {
         pin_str.clear();
     }
 
-    //TODO Not to be used if not using non_networking_test_framework.
-    let data_store = maidsafe_client::client::non_networking_test_framework::get_new_data_store();
-
     // Account Creation
     println!("\nTrying to create an account ...");
 
-    match maidsafe_client::client::Client::create_account(&keyword, pin, &password, data_store.clone()) {
+    match maidsafe_client::client::Client::create_account(&keyword, pin, &password) {
         Ok(_) => {
             println!("Account Created Successfully !!");
         },
@@ -66,7 +63,7 @@ fn create_account() -> Result<maidsafe_client::client::Client, String> {
 
     // Log into the created account
     println!("\nTrying to log into the created account using supplied credentials ...");
-    match maidsafe_client::client::Client::log_in(&keyword, pin, &password, data_store.clone()) {
+    match maidsafe_client::client::Client::log_in(&keyword, pin, &password) {
         Ok(client) => {
             println!("Account Login Successful !!");
             Ok(client)

--- a/examples/self_authentication.rs
+++ b/examples/self_authentication.rs
@@ -47,14 +47,11 @@ fn main() {
         pin_str.clear();
     }
 
-    //TODO Not to be used if not using non_networking_test_framework.
-    let data_store = maidsafe_client::client::non_networking_test_framework::get_new_data_store();
-
     // Account Creation
     {
         println!("\nTrying to create an account ...");
 
-        match maidsafe_client::client::Client::create_account(&keyword, pin, &password, data_store.clone()) {
+        match maidsafe_client::client::Client::create_account(&keyword, pin, &password) {
             Ok(_) => println!("Account Created Successfully !!"),
             Err(io_error)  => println!("Account Creation Failed !! Reason: {:?}", io_error.description()),
         }
@@ -66,7 +63,7 @@ fn main() {
     // Log into the created account
     {
         println!("\nTrying to log into the created account using supplied credentials ...");
-        match maidsafe_client::client::Client::log_in(&keyword, pin, &password, data_store.clone()) {
+        match maidsafe_client::client::Client::log_in(&keyword, pin, &password) {
             Ok(_) => println!("Account Login Successful !!"),
             Err(io_error)  => println!("Account Login Failed !! Reason: {:?}", io_error.description()),
         }
@@ -100,7 +97,7 @@ fn main() {
         // Log into the created account
         {
             println!("\nTrying to log in ...");
-            match maidsafe_client::client::Client::log_in(&keyword, pin, &password, data_store.clone()) {
+            match maidsafe_client::client::Client::log_in(&keyword, pin, &password) {
                 Ok(_) => {
                     println!("Account Login Successful !!");
                     break;

--- a/src/nfs/helper/directory_helper.rs
+++ b/src/nfs/helper/directory_helper.rs
@@ -214,8 +214,7 @@ mod test {
 
         ::client::Client::create_account(&keyword,
                                          pin,
-                                         &password,
-                                         ::std::sync::Arc::new(::std::sync::Mutex::new(::std::collections::BTreeMap::new()))).ok().unwrap()
+                                         &password).ok().unwrap()
     }
 
     #[test]

--- a/src/nfs/helper/file_helper.rs
+++ b/src/nfs/helper/file_helper.rs
@@ -143,8 +143,7 @@ mod test {
 
         ::client::Client::create_account(&keyword,
                                          pin,
-                                         &password,
-                                         ::std::sync::Arc::new(::std::sync::Mutex::new(::std::collections::BTreeMap::new()))).ok().unwrap()
+                                         &password).ok().unwrap()
     }
 
 

--- a/src/nfs/rest/blob.rs
+++ b/src/nfs/rest/blob.rs
@@ -71,11 +71,7 @@ impl Blob {
 #[cfg(test)]
 mod test {
     use super::*;
-    use ::std::sync::Arc;
-    use ::std::sync::Mutex;
-    use ::std::collections::BTreeMap;
     use std::thread::sleep_ms;
-    use ::client::Client;
     use nfs::file::File;
     use nfs::metadata::Metadata;
     use self_encryption::datamap::DataMap;

--- a/src/nfs/rest/container.rs
+++ b/src/nfs/rest/container.rs
@@ -415,42 +415,25 @@ mod test {
     use super::*;
     use ::std::sync::Arc;
     use ::std::sync::Mutex;
-    use ::std::collections::BTreeMap;
-    use std::thread::sleep_ms;
-    use ::client;
     use ::client::Client;
-    use nfs::directory_listing::DirectoryListing;
-    use nfs::helper::DirectoryHelper;
-    use routing::NameType;
-
-    fn dummy_client() -> Client {
-        let keyword = ::utility::generate_random_string(10);
-        let password = ::utility::generate_random_string(10);
-        let pin = ::utility::generate_random_pin();
-        let map = Arc::new(Mutex::new(BTreeMap::new()));
-
-        Client::create_account(&keyword, pin, &password, map).ok().unwrap()
-    }
 
     fn test_client() -> Client {
         let keyword = ::utility::generate_random_string(10);
         let password = ::utility::generate_random_string(10);
         let pin = ::utility::generate_random_pin();
-        let data_store = client::non_networking_test_framework::get_new_data_store();
 
-        Client::create_account(&keyword, pin, &password, data_store.clone()).ok().unwrap()
+        Client::create_account(&keyword, pin, &password).ok().unwrap()
     }
 
     #[test]
     fn authorise_container() {
-        let mut client = Arc::new(Mutex::new(test_client()));
+        let client = Arc::new(Mutex::new(test_client()));
         assert!(Container::authorise(client.clone(), None).is_ok(), true);
     }
 
-
     #[test]
     fn create_container() {
-        let mut client = Arc::new(Mutex::new(test_client()));
+        let client = Arc::new(Mutex::new(test_client()));
         let mut container = Container::authorise(client.clone(), None).unwrap();
         container.create("Home".to_string()).unwrap();
 
@@ -461,7 +444,7 @@ mod test {
 
     #[test]
     fn delete_container() {
-        let mut client = Arc::new(Mutex::new(test_client()));
+        let client = Arc::new(Mutex::new(test_client()));
         let mut container = Container::authorise(client.clone(), None).unwrap();
         container.create("Home".to_string()).unwrap();
 
@@ -477,7 +460,7 @@ mod test {
 
     #[test]
     fn create_update_delete_blob() {
-        let mut client = Arc::new(Mutex::new(test_client()));
+        let client = Arc::new(Mutex::new(test_client()));
         let mut container = Container::authorise(client.clone(), None).unwrap();
         container.create("Home".to_string()).unwrap();
 
@@ -519,11 +502,11 @@ mod test {
         container.create("Public".to_string()).unwrap();
         let mut public_container = container.get_container("Public".to_string(), None).unwrap();
         assert_eq!(public_container.get_blobs().len(), 0);
-        home_container.copy_blob("sample.txt".to_string(), public_container.get_id());
+        let _ = home_container.copy_blob("sample.txt".to_string(), public_container.get_id());
         public_container = container.get_container("Public".to_string(), None).unwrap();
         assert_eq!(public_container.get_blobs().len(), 1);
 
-        home_container.delete_blob("sample.txt".to_string());
+        let _ = home_container.delete_blob("sample.txt".to_string());
         assert_eq!(home_container.get_blobs().len(), 0);
     }
 }


### PR DESCRIPTION
Without this there will be a lot of manual change required in form of commenting and un-commenting code to link with either Mock or Routing. With this PR the following is achieved:

<0> Seamless transitioning between Mock and Actual routing by passing or not-passing:
`cargo test` => will use Mock
`cargo test --features "USE_ACTUAL_ROUTING"` => will use routing crate.
similarly for `cargo build` etc
<1> Data Store is now persistent after this change to mimic routing crate's network-storage more closely.
<2> Removal of majority of warnings.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_client/78)
<!-- Reviewable:end -->
