### PR TITLE
MAID-1219_Ids moved from maidsafe_types

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ etc
 
 ##TODO (rust_3 sprint)
 ### [0.1.2]
-- [ ] [MAID-1209](https://maidsafe.atlassian.net/browse/MAID-1209) Remove NFS API
+- [X] [MAID-1209](https://maidsafe.atlassian.net/browse/MAID-1209) Remove NFS API
 
 ### [0.1.3]
-- [ ] [MAID-1219](https://maidsafe.atlassian.net/browse/MAID-1219) Implement Private and Public types
+- [X] [MAID-1219](https://maidsafe.atlassian.net/browse/MAID-1219) Implement Private and Public types
 
 ### [0.1.4]
 - [ ] [MAID-1248](https://maidsafe.atlassian.net/browse/MAID-1248) Name the spawned rust threads
@@ -52,8 +52,6 @@ etc
 - [ ] [MAID-1249](https://maidsafe.atlassian.net/browse/MAID-1249) Implement Unified Structured Datatype
     - [ ] [MAID-1252](https://maidsafe.atlassian.net/browse/MAID-1252) Mock Unified StructuredData and ImmutableData
     - [ ] [MAID-1253](https://maidsafe.atlassian.net/browse/MAID-1253) Update Mock Routing to support Mock Unified SturcturedData and ImmutableData
-    - [ ] [MAID-1220](https://maidsafe.atlassian.net/browse/MAID-1220) Update the SessionPacket struct
-    - [ ] [MAID-1221](https://maidsafe.atlassian.net/browse/MAID-1221) Update client API to get and set configuration directory ids
     - [ ] [MAID-1222](https://maidsafe.atlassian.net/browse/MAID-1222) Compute size of Structured Data
     - [ ] [MAID-1223](https://maidsafe.atlassian.net/browse/MAID-1223) Implement a handler for Storing UnVersioned Structured Data
     - [ ] [MAID-1224](https://maidsafe.atlassian.net/browse/MAID-1224) Implement a handler for Retrieving Content of UnVersioned Structured Data

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -108,7 +108,7 @@ impl Client {
                     cloned_routing_client.lock().unwrap().run();
                 }
             })),
-        };        
+        };
 
         let encrypted_account = maidsafe_types::ImmutableData::new(client.account.encrypt(password, pin).ok().unwrap());
         let put_res = client.routing.lock().unwrap().put(encrypted_account.clone());

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -108,13 +108,7 @@ impl Client {
                     cloned_routing_client.lock().unwrap().run();
                 }
             })),
-        };
-
-        {
-            let destination = client.account.get_public_maid().name();
-            let boxed_public_maid = Box::new(client.account.get_public_maid().clone());
-            let _ = client.routing.lock().unwrap().unauthorised_put(destination, boxed_public_maid);
-        }
+        };        
 
         let encrypted_account = maidsafe_types::ImmutableData::new(client.account.encrypt(password, pin).ok().unwrap());
         let put_res = client.routing.lock().unwrap().put(encrypted_account.clone());

--- a/src/client/user_account.rs
+++ b/src/client/user_account.rs
@@ -21,7 +21,6 @@ use cbor;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
 
 use routing;
-use maidsafe_types;
 
 static MAIDSAFE_VERSION_LABEL : &'static str = "MaidSafe Version 1 Key Derivation";
 
@@ -30,13 +29,13 @@ static MAIDSAFE_VERSION_LABEL : &'static str = "MaidSafe Version 1 Key Derivatio
 /// supplied credentials to retrieve all the Maid/Mpid etc keys of the user and also his Root
 /// Directory ID if he has put data onto the network.
 pub struct Account {
-    an_maid: maidsafe_types::RevocationIdType,
-    maid: maidsafe_types::IdType,
-    public_maid: maidsafe_types::PublicIdType,
+    an_maid: ::id::RevocationIdType,
+    maid: ::id::IdType,
+    public_maid: ::id::PublicIdType,
 
-    an_mpid: maidsafe_types::RevocationIdType,
-    mpid: maidsafe_types::IdType,
-    public_mpid: maidsafe_types::PublicIdType,
+    an_mpid: ::id::RevocationIdType,
+    mpid: ::id::IdType,
+    public_mpid: ::id::PublicIdType,
 
     root_dir_id: Option<routing::NameType>,
 }
@@ -45,13 +44,13 @@ pub struct Account {
 impl Account {
     /// Create a new Session Packet with Randomly generated Maid keys for the user
     pub fn new(root_dir_id: Option<routing::NameType>) -> Account {
-        let an_maid = maidsafe_types::RevocationIdType::new::<maidsafe_types::MaidTypeTags>();
-        let maid = maidsafe_types::IdType::new(&an_maid);
-        let public_maid = maidsafe_types::PublicIdType::new(&maid, &an_maid);
+        let an_maid = ::id::RevocationIdType::new::<::id::MaidTypeTags>();
+        let maid = ::id::IdType::new(&an_maid);
+        let public_maid = ::id::PublicIdType::new(&maid, &an_maid);
 
-        let an_mpid = maidsafe_types::RevocationIdType::new::<maidsafe_types::MpidTypeTags>();
-        let mpid = maidsafe_types::IdType::new(&an_mpid);
-        let public_mpid = maidsafe_types::PublicIdType::new(&mpid, &an_mpid);
+        let an_mpid = ::id::RevocationIdType::new::<::id::MpidTypeTags>();
+        let mpid = ::id::IdType::new(&an_mpid);
+        let public_mpid = ::id::PublicIdType::new(&mpid, &an_mpid);
 
         Account {
             an_maid: an_maid,
@@ -65,32 +64,32 @@ impl Account {
     }
 
     /// Get user's AnMAID
-    pub fn get_an_maid(&self) -> &maidsafe_types::RevocationIdType {
+    pub fn get_an_maid(&self) -> &::id::RevocationIdType {
         &self.an_maid
     }
 
     /// Get user's MAID
-    pub fn get_maid(&self) -> &maidsafe_types::IdType {
+    pub fn get_maid(&self) -> &::id::IdType {
         &self.maid
     }
 
     /// Get user's Public-MAID
-    pub fn get_public_maid(&self) -> &maidsafe_types::PublicIdType {
+    pub fn get_public_maid(&self) -> &::id::PublicIdType {
         &self.public_maid
     }
 
     /// Get user's AnMPID
-    pub fn get_an_mpid(&self) -> &maidsafe_types::RevocationIdType {
+    pub fn get_an_mpid(&self) -> &::id::RevocationIdType {
         &self.an_mpid
     }
 
     /// Get user's MPID
-    pub fn get_mpid(&self) -> &maidsafe_types::IdType {
+    pub fn get_mpid(&self) -> &::id::IdType {
         &self.mpid
     }
 
     /// Get user's Public-MPID
-    pub fn get_public_mpid(&self) -> &maidsafe_types::PublicIdType {
+    pub fn get_public_mpid(&self) -> &::id::PublicIdType {
         &self.public_mpid
     }
 

--- a/src/data_parser.rs
+++ b/src/data_parser.rs
@@ -22,18 +22,6 @@ pub enum Parser {
     /// Parser Variant
     StructuredData(::maidsafe_types::StructuredData),
     /// Parser Variant
-    Maid(::id::IdType),
-    /// Parser Variant
-    Mpid(::id::IdType),
-    /// Parser Variant
-    AnMaid(::id::RevocationIdType),
-    /// Parser Variant
-    AnMpid(::id::RevocationIdType),
-    /// Parser Variant
-    PublicMaid(::id::PublicIdType),
-    /// Parser Variant
-    PublicMpid(::id::PublicIdType),
-    /// Parser Variant
     Unknown(u64),
 }
 
@@ -44,12 +32,6 @@ impl ::rustc_serialize::Decodable for Parser {
         match tag {
             ::maidsafe_types::data_tags::IMMUTABLE_DATA_TAG  => Ok(Parser::ImmutableData(try!(::rustc_serialize::Decodable::decode(d)))),
             ::maidsafe_types::data_tags::STRUCTURED_DATA_TAG => Ok(Parser::StructuredData(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::id::data_tags::MAID_TAG            => Ok(Parser::Maid(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::id::data_tags::MPID_TAG            => Ok(Parser::Mpid(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::id::data_tags::AN_MAID_TAG         => Ok(Parser::AnMaid(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::id::data_tags::AN_MPID_TAG         => Ok(Parser::AnMpid(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::id::data_tags::PUBLIC_MAID_TAG     => Ok(Parser::PublicMaid(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::id::data_tags::PUBLIC_MPID_TAG     => Ok(Parser::PublicMpid(try!(::rustc_serialize::Decodable::decode(d)))),
             _ => Ok(Parser::Unknown(tag)),
         }
     }

--- a/src/data_parser.rs
+++ b/src/data_parser.rs
@@ -26,6 +26,7 @@ pub enum Parser {
 }
 
 impl ::rustc_serialize::Decodable for Parser {
+
     fn decode<D: ::rustc_serialize::Decoder>(d: &mut D) -> Result<Parser, D::Error> {
         let tag = try!(d.read_u64());
 
@@ -35,4 +36,5 @@ impl ::rustc_serialize::Decodable for Parser {
             _ => Ok(Parser::Unknown(tag)),
         }
     }
+
 }

--- a/src/data_parser.rs
+++ b/src/data_parser.rs
@@ -22,17 +22,17 @@ pub enum Parser {
     /// Parser Variant
     StructuredData(::maidsafe_types::StructuredData),
     /// Parser Variant
-    Maid(::maidsafe_types::IdType),
+    Maid(::id::IdType),
     /// Parser Variant
-    Mpid(::maidsafe_types::IdType),
+    Mpid(::id::IdType),
     /// Parser Variant
-    AnMaid(::maidsafe_types::RevocationIdType),
+    AnMaid(::id::RevocationIdType),
     /// Parser Variant
-    AnMpid(::maidsafe_types::RevocationIdType),
+    AnMpid(::id::RevocationIdType),
     /// Parser Variant
-    PublicMaid(::maidsafe_types::PublicIdType),
+    PublicMaid(::id::PublicIdType),
     /// Parser Variant
-    PublicMpid(::maidsafe_types::PublicIdType),
+    PublicMpid(::id::PublicIdType),
     /// Parser Variant
     Unknown(u64),
 }
@@ -44,12 +44,12 @@ impl ::rustc_serialize::Decodable for Parser {
         match tag {
             ::maidsafe_types::data_tags::IMMUTABLE_DATA_TAG  => Ok(Parser::ImmutableData(try!(::rustc_serialize::Decodable::decode(d)))),
             ::maidsafe_types::data_tags::STRUCTURED_DATA_TAG => Ok(Parser::StructuredData(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::maidsafe_types::data_tags::MAID_TAG            => Ok(Parser::Maid(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::maidsafe_types::data_tags::MPID_TAG            => Ok(Parser::Mpid(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::maidsafe_types::data_tags::AN_MAID_TAG         => Ok(Parser::AnMaid(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::maidsafe_types::data_tags::AN_MPID_TAG         => Ok(Parser::AnMpid(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::maidsafe_types::data_tags::PUBLIC_MAID_TAG     => Ok(Parser::PublicMaid(try!(::rustc_serialize::Decodable::decode(d)))),
-            ::maidsafe_types::data_tags::PUBLIC_MPID_TAG     => Ok(Parser::PublicMpid(try!(::rustc_serialize::Decodable::decode(d)))),
+            ::id::data_tags::MAID_TAG            => Ok(Parser::Maid(try!(::rustc_serialize::Decodable::decode(d)))),
+            ::id::data_tags::MPID_TAG            => Ok(Parser::Mpid(try!(::rustc_serialize::Decodable::decode(d)))),
+            ::id::data_tags::AN_MAID_TAG         => Ok(Parser::AnMaid(try!(::rustc_serialize::Decodable::decode(d)))),
+            ::id::data_tags::AN_MPID_TAG         => Ok(Parser::AnMpid(try!(::rustc_serialize::Decodable::decode(d)))),
+            ::id::data_tags::PUBLIC_MAID_TAG     => Ok(Parser::PublicMaid(try!(::rustc_serialize::Decodable::decode(d)))),
+            ::id::data_tags::PUBLIC_MPID_TAG     => Ok(Parser::PublicMpid(try!(::rustc_serialize::Decodable::decode(d)))),
             _ => Ok(Parser::Unknown(tag)),
         }
     }

--- a/src/id/id_type.rs
+++ b/src/id/id_type.rs
@@ -104,12 +104,11 @@ impl ::rustc_serialize::Encodable for IdType {
         let (::sodiumoxide::crypto::sign::SecretKey(sec_sign_vec), ::sodiumoxide::crypto::box_::SecretKey(sec_asym_vec)) = self.secret_keys;
         let type_vec = self.type_tag.to_string().into_bytes();
 
-        ::cbor::CborTagEncode::new(self.type_tag, &(
-            type_vec,
-            pub_sign_vec.as_ref(),
-            pub_asym_vec.as_ref(),
-            sec_sign_vec.as_ref(),
-            sec_asym_vec.as_ref())).encode(e)
+        ::cbor::CborTagEncode::new(self.type_tag, &(type_vec,
+                                                    pub_sign_vec.as_ref(),
+                                                    pub_asym_vec.as_ref(),
+                                                    sec_sign_vec.as_ref(),
+                                                    sec_asym_vec.as_ref())).encode(e)
     }
 }
 

--- a/src/id/id_type.rs
+++ b/src/id/id_type.rs
@@ -1,0 +1,220 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+/// IdType
+///
+/// #Examples
+/// ```
+/// use ::maidsafe_client::id::{IdType, RevocationIdType, MaidTypeTags};
+/// // Creating new IdType
+/// let maid  = IdType::new(&RevocationIdType::new::<MaidTypeTags>());
+///
+/// ```
+#[derive(Clone)]
+pub struct IdType {
+    type_tag: u64,
+    public_keys: (::sodiumoxide::crypto::sign::PublicKey, ::sodiumoxide::crypto::box_::PublicKey),
+    secret_keys: (::sodiumoxide::crypto::sign::SecretKey, ::sodiumoxide::crypto::box_::SecretKey),
+}
+
+impl IdType {
+    /// Invoked to create an instance of IdType
+    pub fn new(revocation_id: &::id::RevocationIdType) -> IdType {
+        let asym_keys = ::sodiumoxide::crypto::box_::gen_keypair();
+        let signing_keys = ::sodiumoxide::crypto::sign::gen_keypair();
+
+        IdType {
+            type_tag: revocation_id.type_tags().1,
+            public_keys: (signing_keys.0, asym_keys.0),
+            secret_keys: (signing_keys.1, asym_keys.1),
+        }
+    }
+    /// Returns name
+    pub fn name(&self) -> ::routing::NameType {
+        let combined_iter = (&self.public_keys.0).0.into_iter().chain((&self.public_keys.1).0.into_iter());
+        let mut combined: Vec<u8> = Vec::new();
+        for iter in combined_iter {
+            combined.push(*iter);
+        }
+        for i in self.type_tag.to_string().into_bytes().into_iter() {
+            combined.push(i);
+        }
+        ::routing::NameType(::sodiumoxide::crypto::hash::sha512::hash(&combined).0)
+    }
+    /// Returns the PublicKeys
+    pub fn public_keys(&self) -> &(::sodiumoxide::crypto::sign::PublicKey, ::sodiumoxide::crypto::box_::PublicKey){
+        &self.public_keys
+    }
+    /// Returns the PublicKeys
+    pub fn secret_keys(&self) -> &(::sodiumoxide::crypto::sign::SecretKey, ::sodiumoxide::crypto::box_::SecretKey) {
+        &self.secret_keys
+    }
+    /// Signs the data with the SecretKey and returns the Signed data
+    pub fn sign(&self, data : &[u8]) -> Vec<u8> {
+        return ::sodiumoxide::crypto::sign::sign(&data, &self.secret_keys.0)
+    }
+    /// Encrypts and authenticates data. It returns a ciphertext and the Nonce.
+    pub fn seal(&self, data : &[u8], to : &::sodiumoxide::crypto::box_::PublicKey) -> (Vec<u8>, ::sodiumoxide::crypto::box_::Nonce) {
+        let nonce = ::sodiumoxide::crypto::box_::gen_nonce();
+        let sealed = ::sodiumoxide::crypto::box_::seal(data, &nonce, &to, &self.secret_keys.1);
+        return (sealed, nonce);
+    }
+    /// Verifies and decrypts the data
+    pub fn open(
+        &self,
+        data : &[u8],
+        nonce : &::sodiumoxide::crypto::box_::Nonce,
+        from : &::sodiumoxide::crypto::box_::PublicKey) -> Result<Vec<u8>, ::CryptoError> {
+        return ::sodiumoxide::crypto::box_::open(&data, &nonce, &from, &self.secret_keys.1).ok_or(::CryptoError::Unknown);
+    }
+}
+
+impl PartialEq for IdType {
+    fn eq(&self, other: &IdType) -> bool {
+        // Private keys are mathematically linked, so just check public keys
+        &self.type_tag == &other.type_tag &&
+        ::utility::slice_equal(&self.public_keys.0 .0, &other.public_keys.0 .0) &&
+        ::utility::slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0)
+    }
+}
+
+impl ::std::fmt::Debug for IdType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "IdType {{ type_tag:{}, public_keys: ({:?}, {:?}) }}", self.type_tag, self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec())
+    }
+}
+
+impl ::rustc_serialize::Encodable for IdType {
+    fn encode<E: ::rustc_serialize::Encoder>(&self, e: &mut E)->Result<(), E::Error> {
+        let (::sodiumoxide::crypto::sign::PublicKey(pub_sign_vec), ::sodiumoxide::crypto::box_::PublicKey(pub_asym_vec)) = self.public_keys;
+        let (::sodiumoxide::crypto::sign::SecretKey(sec_sign_vec), ::sodiumoxide::crypto::box_::SecretKey(sec_asym_vec)) = self.secret_keys;
+        let type_vec = self.type_tag.to_string().into_bytes();
+
+        ::cbor::CborTagEncode::new(self.type_tag, &(
+            type_vec,
+            pub_sign_vec.as_ref(),
+            pub_asym_vec.as_ref(),
+            sec_sign_vec.as_ref(),
+            sec_asym_vec.as_ref())).encode(e)
+    }
+}
+
+impl ::rustc_serialize::Decodable for IdType {
+    fn decode<D: ::rustc_serialize::Decoder>(d: &mut D)-> Result<IdType, D::Error> {
+        let (tag_type_vec, pub_sign_vec, pub_asym_vec, sec_sign_vec, sec_asym_vec) :
+            (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) = try!(::rustc_serialize::Decodable::decode(d));
+        let pub_sign_arr = convert_to_array!(pub_sign_vec, ::sodiumoxide::crypto::sign::PUBLICKEYBYTES);
+        let pub_asym_arr = convert_to_array!(pub_asym_vec, ::sodiumoxide::crypto::box_::PUBLICKEYBYTES);
+        let sec_sign_arr = convert_to_array!(sec_sign_vec, ::sodiumoxide::crypto::sign::SECRETKEYBYTES);
+        let sec_asym_arr = convert_to_array!(sec_asym_vec, ::sodiumoxide::crypto::box_::SECRETKEYBYTES);
+
+        if pub_sign_arr.is_none() || pub_asym_arr.is_none() || sec_sign_arr.is_none() || sec_asym_arr.is_none() {
+            return Err(d.error("Bad IdType size"));
+        }
+
+        let type_tag: u64 = match String::from_utf8(tag_type_vec) {
+            Ok(string) =>  {
+                match string.parse::<u64>() {
+                    Ok(type_tag) => type_tag,
+                    Err(_) => return Err(d.error("Bad Tag Type"))
+                }
+            },
+            Err(_) => return Err(d.error("Bad Tag Type"))
+        };
+
+        Ok(IdType {
+                type_tag: type_tag,
+                public_keys:(::sodiumoxide::crypto::sign::PublicKey(pub_sign_arr.unwrap()), ::sodiumoxide::crypto::box_::PublicKey(pub_asym_arr.unwrap())),
+                secret_keys: (::sodiumoxide::crypto::sign::SecretKey(sec_sign_arr.unwrap()), ::sodiumoxide::crypto::box_::SecretKey(sec_asym_arr.unwrap()))
+            })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate rand;
+
+    use self::rand::Rng;
+    use ::id::Random;
+
+    impl Random for ::id::IdType {
+        fn generate_random() -> ::id::IdType {
+            ::id::IdType::new(&::id::RevocationIdType::new::<::id::MaidTypeTags>())
+        }
+    }
+
+#[test]
+    fn serialisation_maid() {
+        let obj_before = ::id::IdType::generate_random();
+
+        let mut e = ::cbor::Encoder::from_memory();
+        e.encode(&[&obj_before]).unwrap();
+
+        let mut d = ::cbor::Decoder::from_bytes(e.as_bytes());
+        match d.decode().next().unwrap().unwrap() {
+            ::data_parser::Parser::Maid(obj_after) => {
+                let &(::sodiumoxide::crypto::sign::PublicKey(pub_sign_arr_before), ::sodiumoxide::crypto::box_::PublicKey(pub_asym_arr_before)) = obj_before.public_keys();
+                let &(::sodiumoxide::crypto::sign::PublicKey(pub_sign_arr_after), ::sodiumoxide::crypto::box_::PublicKey(pub_asym_arr_after)) = obj_after.public_keys();
+                let &(::sodiumoxide::crypto::sign::SecretKey(sec_sign_arr_before), ::sodiumoxide::crypto::box_::SecretKey(sec_asym_arr_before)) = &obj_before.secret_keys;
+                let &(::sodiumoxide::crypto::sign::SecretKey(sec_sign_arr_after), ::sodiumoxide::crypto::box_::SecretKey(sec_asym_arr_after)) = &obj_after.secret_keys;
+
+                assert_eq!(pub_sign_arr_before, pub_sign_arr_after);
+                assert_eq!(pub_asym_arr_before, pub_asym_arr_after);
+                assert!(::utility::slice_equal(&sec_sign_arr_before, &sec_sign_arr_after));
+                assert_eq!(sec_asym_arr_before, sec_asym_arr_after);
+            },
+            _ => panic!("Unexpected!"),
+        }
+    }
+
+#[test]
+    fn generation() {
+        let maid1 = ::id::IdType::generate_random();
+        let maid2 = ::id::IdType::generate_random();
+        let maid2_clone = maid2.clone();
+
+        assert_eq!(maid2, maid2_clone);
+        assert!(!(maid2 != maid2_clone));
+        assert!(maid1 != maid2);
+
+        let random_bytes = rand::thread_rng().gen_iter::<u8>().take(100).collect::<Vec<u8>>();
+        {
+            let sign1 = maid1.sign(&random_bytes);
+            let sign2 = maid2.sign(&random_bytes);
+            assert!(sign1 != sign2);
+
+            assert!(::sodiumoxide::crypto::sign::verify(&sign1, &maid1.public_keys().0).is_some());
+            assert!(::sodiumoxide::crypto::sign::verify(&sign2, &maid1.public_keys().0).is_none());
+
+            assert!(::sodiumoxide::crypto::sign::verify(&sign2, &maid2.public_keys().0).is_some());
+            assert!(::sodiumoxide::crypto::sign::verify(&sign2, &maid1.public_keys().0).is_none());
+        }
+        {
+            let maid3 = ::id::IdType::generate_random();
+
+            let encrypt1 = maid1.seal(&random_bytes, &maid3.public_keys().1);
+            let encrypt2 = maid2.seal(&random_bytes, &maid3.public_keys().1);
+            assert!(encrypt1.0 != encrypt2.0);
+
+            assert!(maid3.open(&encrypt1.0, &encrypt1.1, &maid1.public_keys().1).is_ok());
+            assert!(maid3.open(&encrypt1.0, &encrypt1.1, &maid2.public_keys().1).is_err());
+
+            assert!(maid3.open(&encrypt2.0, &encrypt2.1, &maid2.public_keys().1).is_ok());
+            assert!(maid3.open(&encrypt2.0, &encrypt2.1, &maid1.public_keys().1).is_err());
+        }
+    }
+}

--- a/src/id/mod.rs
+++ b/src/id/mod.rs
@@ -1,0 +1,80 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+/// AnMaid
+pub mod revocation_id_type;
+/// Maid
+pub mod id_type;
+/// PublicMaid
+pub mod public_id_type;
+
+pub use self::revocation_id_type::*;
+pub use self::id_type::*;
+pub use self::public_id_type::*;
+
+/// Interface to IdTypes
+pub trait IdTypeTags {
+    /// returns tag type for revocation id type
+    fn revocation_id_type_tag(&self) -> u64;
+    /// returns tag type for id type
+    fn id_type_tag(&self) -> u64;
+    /// returns tag type for public id type
+    fn public_id_type_tag(&self) -> u64;
+}
+
+/// TypeTags for Maid type variants
+pub struct MaidTypeTags;
+
+/// TypeTags for Maid type variants
+pub struct MpidTypeTags;
+
+impl IdTypeTags for MaidTypeTags {
+    /// returns tag type for AnMaid type
+    fn revocation_id_type_tag(&self) -> u64 { data_tags::AN_MAID_TAG }
+    /// returns tag type for Maid type
+    fn id_type_tag(&self) -> u64 { data_tags::MAID_TAG }
+    /// returns tag type for PublicMaid type
+    fn public_id_type_tag(&self) -> u64 { data_tags::PUBLIC_MAID_TAG }
+}
+
+impl IdTypeTags for MpidTypeTags {
+    /// returns tag type for AnMpid type
+    fn revocation_id_type_tag(&self) -> u64 { data_tags::AN_MPID_TAG }
+    /// returns tag type for Mpid type
+    fn id_type_tag(&self) -> u64 { data_tags::MPID_TAG }
+    /// returns tag type for PublicMpid type
+    fn public_id_type_tag(&self) -> u64 { data_tags::PUBLIC_MPID_TAG }
+}
+
+/// Random trait is used to generate random instances.
+/// Used in the test mod
+pub trait Random {
+    /// Generates a random instance and returns the created random instance
+    fn generate_random() -> Self;
+}
+
+/// All Maidsafe ID tags
+#[allow(missing_docs)]
+pub mod data_tags {
+    pub const MAIDSAFE_DATA_TAG: u64 = ::MAIDSAFE_TAG + 100;
+    pub const AN_MPID_TAG: u64                    = MAIDSAFE_DATA_TAG + 5;
+    pub const AN_MAID_TAG: u64                    = MAIDSAFE_DATA_TAG + 6;
+    pub const MAID_TAG: u64                       = MAIDSAFE_DATA_TAG + 7;
+    pub const MPID_TAG: u64                       = MAIDSAFE_DATA_TAG + 8;
+    pub const PUBLIC_MAID_TAG: u64                = MAIDSAFE_DATA_TAG + 9;
+    pub const PUBLIC_MPID_TAG: u64                = MAIDSAFE_DATA_TAG + 10;
+}

--- a/src/id/public_id_type.rs
+++ b/src/id/public_id_type.rs
@@ -36,6 +36,7 @@ pub struct PublicIdType {
 }
 
 impl PartialEq for PublicIdType {
+
     fn eq(&self, other: &PublicIdType) -> bool {
         &self.type_tag == &other.type_tag &&
         ::utility::slice_equal(&self.public_keys.0 .0, &other.public_keys.0 .0) &&
@@ -43,17 +44,21 @@ impl PartialEq for PublicIdType {
         ::utility::slice_equal(&self.revocation_public_key.0, &other.revocation_public_key.0) &&
         ::utility::slice_equal(&self.signature.0, &other.signature.0)
     }
+
 }
 
 impl ::std::fmt::Debug for PublicIdType {
+
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         write!(f, "PublicIdType {{ type_tag:{}, public_keys:({:?}, {:?}), revocation_public_key:{:?}, signature:{:?}}}",
             self.type_tag, self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(), self.revocation_public_key.0.to_vec(),
             self.signature.0.to_vec())
     }
+
 }
 
 impl PublicIdType {
+
     /// An instanstance of the PublicIdType can be created using the new()
     pub fn new(id_type: &::id::IdType, revocation_id: &::id::RevocationIdType) -> PublicIdType {
         let type_tag = revocation_id.type_tags().2;
@@ -103,9 +108,11 @@ impl PublicIdType {
     pub fn signature(&self) -> &::sodiumoxide::crypto::sign::Signature {
         &self.signature
     }
+
 }
 
 impl ::rustc_serialize::Encodable for PublicIdType {
+
     fn encode<E: ::rustc_serialize::Encoder>(&self, e: &mut E)->Result<(), E::Error> {
         let (::sodiumoxide::crypto::sign::PublicKey(ref pub_sign_vec), ::sodiumoxide::crypto::box_::PublicKey(pub_asym_vec)) = self.public_keys;
         let ::sodiumoxide::crypto::sign::PublicKey(ref revocation_public_key_vec) = self.revocation_public_key;
@@ -117,10 +124,12 @@ impl ::rustc_serialize::Encodable for PublicIdType {
                                                     revocation_public_key_vec.as_ref(),
                                                     signature.as_ref())).encode(e)
     }
+
 }
 
 impl ::rustc_serialize::Decodable for PublicIdType {
-    fn decode<D: ::rustc_serialize::Decoder>(d: &mut D)-> Result<PublicIdType, D::Error> {
+
+    fn decode<D: ::rustc_serialize::Decoder>(d: &mut D) -> Result<PublicIdType, D::Error> {
         let _ = try!(d.read_u64());
         let (tag_type_vec, pub_sign_vec, pub_asym_vec, revocation_public_key_vec, signature_vec):
             (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) = try!(::rustc_serialize::Decodable::decode(d));
@@ -151,6 +160,7 @@ impl ::rustc_serialize::Decodable for PublicIdType {
                 signature: ::sodiumoxide::crypto::sign::Signature(signature_arr.unwrap()),
             })
     }
+
 }
 
 #[cfg(test)]

--- a/src/id/public_id_type.rs
+++ b/src/id/public_id_type.rs
@@ -1,0 +1,246 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use routing::sendable::Sendable;
+
+/// PublicIdType
+///
+/// #Examples
+///
+/// ```
+/// use ::maidsafe_client::id::{IdType, RevocationIdType, MaidTypeTags, PublicIdType};
+///
+///  let revocation_maid = RevocationIdType::new::<::maidsafe_client::id::MaidTypeTags>();
+///  let maid = IdType::new(&revocation_maid);
+///  let public_maid  = PublicIdType::new(&maid, &revocation_maid);
+/// ```
+
+#[derive(Clone)]
+pub struct PublicIdType {
+    type_tag: u64,
+    public_keys: (::sodiumoxide::crypto::sign::PublicKey, ::sodiumoxide::crypto::box_::PublicKey),
+    revocation_public_key: ::sodiumoxide::crypto::sign::PublicKey,
+    signature: ::sodiumoxide::crypto::sign::Signature,
+}
+
+impl Sendable for PublicIdType {
+    fn name(&self) -> ::routing::NameType {
+        let combined_iter = (self.public_keys.0).0.into_iter().chain((self.public_keys.1).0.into_iter());
+        let mut combined: Vec<u8> = Vec::new();
+        for iter in combined_iter {
+            combined.push(*iter);
+        }
+        for i in self.type_tag.to_string().into_bytes().into_iter() {
+            combined.push(i);
+        }
+        for i in 0..::sodiumoxide::crypto::sign::SIGNATUREBYTES {
+            combined.push(self.signature.0[i]);
+        }
+        ::routing::NameType(::sodiumoxide::crypto::hash::sha512::hash(&combined).0)
+    }
+
+    fn type_tag(&self) -> u64 {
+        self.type_tag.clone()
+    }
+
+    fn serialised_contents(&self) -> Vec<u8> {
+        let mut e = ::cbor::Encoder::from_memory();
+        e.encode(&[&self]).unwrap();
+        e.into_bytes()
+    }
+
+    fn refresh(&self) -> bool {
+        false
+    }
+
+    fn merge(&self, _: Vec<Box<Sendable>>) -> Option<Box<Sendable>> { None }
+}
+
+impl PartialEq for PublicIdType {
+    fn eq(&self, other: &PublicIdType) -> bool {
+        &self.type_tag == &other.type_tag &&
+        ::utility::slice_equal(&self.public_keys.0 .0, &other.public_keys.0 .0) &&
+        ::utility::slice_equal(&self.public_keys.1 .0, &other.public_keys.1 .0) &&
+        ::utility::slice_equal(&self.revocation_public_key.0, &other.revocation_public_key.0) &&
+        ::utility::slice_equal(&self.signature.0, &other.signature.0)
+    }
+}
+
+impl ::std::fmt::Debug for PublicIdType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        write!(f, "PublicIdType {{ type_tag:{}, public_keys:({:?}, {:?}), revocation_public_key:{:?}, signature:{:?}}}",
+            self.type_tag, self.public_keys.0 .0.to_vec(), self.public_keys.1 .0.to_vec(), self.revocation_public_key.0.to_vec(),
+            self.signature.0.to_vec())
+    }
+}
+
+impl PublicIdType {
+    /// An instanstance of the PublicIdType can be created using the new()
+    pub fn new(id_type: &::id::IdType, revocation_id: &::id::RevocationIdType) -> PublicIdType {
+        let type_tag = revocation_id.type_tags().2;
+        let public_keys = id_type.public_keys().clone();
+        let revocation_public_key = revocation_id.public_key();
+        let combined_iter = (public_keys.0).0.into_iter().chain((public_keys.1).0.into_iter().chain(revocation_public_key.0.into_iter()));
+        let mut combined: Vec<u8> = Vec::new();
+        for iter in combined_iter {
+            combined.push(*iter);
+        }
+        for i in type_tag.to_string().into_bytes().into_iter() {
+            combined.push(i);
+        }
+        let message_length = combined.len();
+        let signature = revocation_id.sign(&combined).into_iter().skip(message_length).collect::<Vec<_>>();
+        let signature_arr = convert_to_array!(signature, ::sodiumoxide::crypto::sign::SIGNATUREBYTES);
+        PublicIdType { type_tag: type_tag, public_keys: public_keys,
+             revocation_public_key: revocation_id.public_key().clone(),
+             signature: ::sodiumoxide::crypto::sign::Signature(signature_arr.unwrap()) }
+    }
+    /// Returns the PublicKeys
+    pub fn public_keys(&self) -> &(::sodiumoxide::crypto::sign::PublicKey, ::sodiumoxide::crypto::box_::PublicKey) {
+        &self.public_keys
+    }
+    /// Returns revocation public key
+    pub fn revocation_public_key(&self) -> &::sodiumoxide::crypto::sign::PublicKey {
+        &self.revocation_public_key
+    }
+    /// Returns the Signature of PublicIdType
+    pub fn signature(&self) -> &::sodiumoxide::crypto::sign::Signature {
+        &self.signature
+    }
+}
+
+impl ::rustc_serialize::Encodable for PublicIdType {
+    fn encode<E: ::rustc_serialize::Encoder>(&self, e: &mut E)->Result<(), E::Error> {
+        let (::sodiumoxide::crypto::sign::PublicKey(ref pub_sign_vec), ::sodiumoxide::crypto::box_::PublicKey(pub_asym_vec)) = self.public_keys;
+        let ::sodiumoxide::crypto::sign::PublicKey(ref revocation_public_key_vec) = self.revocation_public_key;
+        let ::sodiumoxide::crypto::sign::Signature(ref signature) = self.signature;
+        let type_vec = self.type_tag.to_string().into_bytes();
+        ::cbor::CborTagEncode::new(self.type_tag, &(
+                type_vec,
+                pub_sign_vec.as_ref(),
+                pub_asym_vec.as_ref(),
+                revocation_public_key_vec.as_ref(),
+                signature.as_ref())
+            ).encode(e)
+    }
+}
+
+impl ::rustc_serialize::Decodable for PublicIdType {
+    fn decode<D: ::rustc_serialize::Decoder>(d: &mut D)-> Result<PublicIdType, D::Error> {
+    let (tag_type_vec, pub_sign_vec, pub_asym_vec, revocation_public_key_vec, signature_vec):
+        (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) = try!(::rustc_serialize::Decodable::decode(d));
+    let pub_sign_arr = convert_to_array!(pub_sign_vec, ::sodiumoxide::crypto::sign::PUBLICKEYBYTES);
+    let pub_asym_arr = convert_to_array!(pub_asym_vec, ::sodiumoxide::crypto::box_::PUBLICKEYBYTES);
+    let revocation_public_key_arr = convert_to_array!(revocation_public_key_vec, ::sodiumoxide::crypto::box_::PUBLICKEYBYTES);
+    let signature_arr = convert_to_array!(signature_vec, ::sodiumoxide::crypto::sign::SIGNATUREBYTES);
+
+    if pub_sign_arr.is_none() || pub_asym_arr.is_none() || revocation_public_key_arr.is_none()
+        || signature_arr.is_none() {
+             return Err(d.error("Bad PublicIdType size"));
+    }
+
+    let type_tag: u64 = match String::from_utf8(tag_type_vec) {
+        Ok(string) =>  {
+            match string.parse::<u64>() {
+                Ok(type_tag) => type_tag,
+                Err(_) => return Err(d.error("Bad Tag Type")),
+            }
+        },
+        Err(_) => return Err(d.error("Bad Tag Type")),
+    };
+
+    Ok(PublicIdType {
+            type_tag: type_tag,
+            public_keys: (::sodiumoxide::crypto::sign::PublicKey(pub_sign_arr.unwrap()), ::sodiumoxide::crypto::box_::PublicKey(pub_asym_arr.unwrap())),
+            revocation_public_key: ::sodiumoxide::crypto::sign::PublicKey(revocation_public_key_arr.unwrap()),
+            signature: ::sodiumoxide::crypto::sign::Signature(signature_arr.unwrap()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::PublicIdType;
+    use routing::types::array_as_vector;
+    use ::id::Random;
+    
+    impl Random for PublicIdType {
+        fn generate_random() -> PublicIdType {
+            let revocation_maid = ::id::RevocationIdType::new::<::id::MaidTypeTags>();
+            let maid = ::id::IdType::new(&revocation_maid);
+            PublicIdType::new(&maid, &revocation_maid)
+        }
+    }
+
+    #[test]
+    fn create_public_mpid() {
+        let revocation_mpid = ::id::RevocationIdType::new::<::id::MpidTypeTags>();
+        let mpid = ::id::IdType::new(&revocation_mpid);
+        PublicIdType::new(&mpid, &revocation_mpid);
+    }
+
+    #[test]
+    fn serialisation_public_maid() {
+        let obj_before: PublicIdType = ::id::Random::generate_random();
+
+        let mut e = ::cbor::Encoder::from_memory();
+        e.encode(&[&obj_before]).unwrap();
+
+        let mut d = ::cbor::Decoder::from_bytes(e.as_bytes());
+        match d.decode().next().unwrap().unwrap() {
+            ::data_parser::Parser::PublicMaid(obj_after) => assert_eq!(obj_before, obj_after),
+            _ => panic!("Unexpected!"),
+        }
+    }
+
+    #[test]
+    fn equality_assertion_public_maid() {
+        let public_maid_first = PublicIdType::generate_random();
+        let public_maid_second = public_maid_first.clone();
+        let public_maid_third = PublicIdType::generate_random();
+        assert_eq!(public_maid_first, public_maid_second);
+        assert!(public_maid_first != public_maid_third);
+    }
+
+    #[test]
+    fn invariant_check() {
+        let revocation_maid = ::id::RevocationIdType::new::<::id::MaidTypeTags>();
+        let maid = ::id::IdType::new(&revocation_maid);
+        let public_maid = PublicIdType::new(&maid, &revocation_maid);
+        let type_tag = public_maid.type_tag;
+        let public_id_keys = public_maid.public_keys;
+        let public_revocation_key = public_maid.revocation_public_key;
+        let combined_keys = (public_id_keys.0).0.into_iter().chain((public_id_keys.1).0
+                                                .into_iter().chain(public_revocation_key.0
+                                                .into_iter()));
+        let mut combined = Vec::new();
+
+        for iter in combined_keys {
+            combined.push(*iter);
+        }
+        for i in type_tag.to_string().into_bytes().into_iter() {
+            combined.push(i);
+        }
+
+        let message_length = combined.len();
+        let signature = revocation_maid.sign(&combined).into_iter().skip(message_length).collect::<Vec<_>>();
+        let signature_array = convert_to_array!(signature, ::sodiumoxide::crypto::sign::SIGNATUREBYTES);
+        let signature = ::sodiumoxide::crypto::sign::Signature(signature_array.unwrap());
+
+        assert_eq!(array_as_vector(&signature.0), array_as_vector(&public_maid.signature().0));
+    }
+}

--- a/src/id/public_id_type.rs
+++ b/src/id/public_id_type.rs
@@ -129,13 +129,11 @@ impl ::rustc_serialize::Encodable for PublicIdType {
         let ::sodiumoxide::crypto::sign::PublicKey(ref revocation_public_key_vec) = self.revocation_public_key;
         let ::sodiumoxide::crypto::sign::Signature(ref signature) = self.signature;
         let type_vec = self.type_tag.to_string().into_bytes();
-        ::cbor::CborTagEncode::new(self.type_tag, &(
-                type_vec,
-                pub_sign_vec.as_ref(),
-                pub_asym_vec.as_ref(),
-                revocation_public_key_vec.as_ref(),
-                signature.as_ref())
-            ).encode(e)
+        ::cbor::CborTagEncode::new(self.type_tag, &(type_vec,
+                                                    pub_sign_vec.as_ref(),
+                                                    pub_asym_vec.as_ref(),
+                                                    revocation_public_key_vec.as_ref(),
+                                                    signature.as_ref())).encode(e)
     }
 }
 
@@ -177,7 +175,7 @@ mod test {
     use super::PublicIdType;
     use routing::types::array_as_vector;
     use ::id::Random;
-    
+
     impl Random for PublicIdType {
         fn generate_random() -> PublicIdType {
             let revocation_maid = ::id::RevocationIdType::new::<::id::MaidTypeTags>();

--- a/src/id/public_id_type.rs
+++ b/src/id/public_id_type.rs
@@ -113,7 +113,7 @@ impl PublicIdType {
 
 impl ::rustc_serialize::Encodable for PublicIdType {
 
-    fn encode<E: ::rustc_serialize::Encoder>(&self, e: &mut E)->Result<(), E::Error> {
+    fn encode<E: ::rustc_serialize::Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
         let (::sodiumoxide::crypto::sign::PublicKey(ref pub_sign_vec), ::sodiumoxide::crypto::box_::PublicKey(pub_asym_vec)) = self.public_keys;
         let ::sodiumoxide::crypto::sign::PublicKey(ref revocation_public_key_vec) = self.revocation_public_key;
         let ::sodiumoxide::crypto::sign::Signature(ref signature) = self.signature;

--- a/src/id/revocation_id_type.rs
+++ b/src/id/revocation_id_type.rs
@@ -31,7 +31,7 @@
 pub struct RevocationIdType {
     type_tags: (u64, u64, u64),  // type tags for revocation, id and public ids
     public_key: ::sodiumoxide::crypto::sign::PublicKey,
-    secret_key: ::sodiumoxide::crypto::sign::SecretKey
+    secret_key: ::sodiumoxide::crypto::sign::SecretKey,
 }
 
 impl PartialEq for RevocationIdType {
@@ -60,7 +60,7 @@ impl RevocationIdType {
         RevocationIdType {
             type_tags: (type_tags.revocation_id_type_tag(), type_tags.id_type_tag(), type_tags.public_id_type_tag()),
             public_key: pub_sign_key,
-            secret_key: sec_sign_key
+            secret_key: sec_sign_key,
         }
     }
 
@@ -105,10 +105,10 @@ fn convert_to_u64(num_vec: Vec<u8>) -> Option<u64> {
          Ok(string) =>  {
              match string.parse::<u64>() {
                  Ok(type_tag) => Some(type_tag),
-                 Err(_) => None
+                 Err(_) => None,
              }
          },
-         Err(_) => None
+         Err(_) => None,
      }
 }
 
@@ -143,9 +143,11 @@ impl ::rustc_serialize::Decodable for RevocationIdType {
             return Err(d.error("Bad RevocationIdType size"));
         }
 
-        Ok(RevocationIdType{ type_tags: (revocation_type_tag.unwrap(), id_type_tag.unwrap(), public_id_type_tag.unwrap()),
-             public_key: ::sodiumoxide::crypto::sign::PublicKey(pub_sign_arr.unwrap()),
-             secret_key: ::sodiumoxide::crypto::sign::SecretKey(sec_sign_arr.unwrap()) })
+        Ok(RevocationIdType {
+                type_tags: (revocation_type_tag.unwrap(), id_type_tag.unwrap(), public_id_type_tag.unwrap()),
+                public_key: ::sodiumoxide::crypto::sign::PublicKey(pub_sign_arr.unwrap()),
+                secret_key: ::sodiumoxide::crypto::sign::SecretKey(sec_sign_arr.unwrap()),
+            })
     }
 }
 
@@ -156,7 +158,7 @@ mod test {
     use super::RevocationIdType;
     use self::rand::Rng;
     use ::id::Random;
-    
+
     impl Random for RevocationIdType {
         fn generate_random() -> RevocationIdType {
             RevocationIdType::new::<::id::MaidTypeTags>()

--- a/src/id/revocation_id_type.rs
+++ b/src/id/revocation_id_type.rs
@@ -128,6 +128,7 @@ impl ::rustc_serialize::Encodable for RevocationIdType {
 
 impl ::rustc_serialize::Decodable for RevocationIdType {
     fn decode<D: ::rustc_serialize::Decoder>(d: &mut D)-> Result<RevocationIdType, D::Error> {
+        let _ = try!(d.read_u64());
         let (revocation_type_tag_vec, id_type_tag_vec, public_id_type_tag_vec , pub_sign_vec, sec_sign_vec):
             (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) = try!(::rustc_serialize::Decodable::decode(d));
         let pub_sign_arr = convert_to_array!(pub_sign_vec, ::sodiumoxide::crypto::sign::PUBLICKEYBYTES);
@@ -175,10 +176,9 @@ mod test {
         e.encode(&[&obj_before]).unwrap();
 
         let mut d = ::cbor::Decoder::from_bytes(e.as_bytes());
-        match d.decode().next().unwrap().unwrap() {
-            ::data_parser::Parser::AnMaid(obj_after) => assert_eq!(obj_before, obj_after),
-            _ => panic!("Unexpected!"),
-        }
+
+        let obj_after = d.decode().next().unwrap().unwrap();
+        assert_eq!(obj_before, obj_after);
     }
 
 #[test]

--- a/src/id/revocation_id_type.rs
+++ b/src/id/revocation_id_type.rs
@@ -27,6 +27,7 @@
 /// let an_maid = ::maidsafe_client::id::RevocationIdType::new::<::maidsafe_client::id::MaidTypeTags>();
 /// ```
 ///
+
 #[derive(Clone)]
 pub struct RevocationIdType {
     type_tags: (u64, u64, u64),  // type tags for revocation, id and public ids
@@ -35,19 +36,23 @@ pub struct RevocationIdType {
 }
 
 impl PartialEq for RevocationIdType {
+
     fn eq(&self, other: &RevocationIdType) -> bool {
         // Private key is mathematically linked, so just check public key
         &self.type_tags == &other.type_tags &&
         ::utility::slice_equal(&self.public_key.0, &other.public_key.0)
     }
+
 }
 
 
 impl ::std::fmt::Debug for RevocationIdType {
+
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         let ::sodiumoxide::crypto::sign::PublicKey(ref public_key) = self.public_key;
         write!(f, "RevocationIdType( type_tags:{:?}, public_key: {:?} )", self.type_tags, public_key)
     }
+
 }
 
 impl RevocationIdType {
@@ -98,6 +103,7 @@ impl RevocationIdType {
     pub fn sign(&self, data : &[u8]) -> Vec<u8> {
         return ::sodiumoxide::crypto::sign::sign(&data, &self.secret_key)
     }
+
 }
 
 fn convert_to_u64(num_vec: Vec<u8>) -> Option<u64> {
@@ -113,6 +119,7 @@ fn convert_to_u64(num_vec: Vec<u8>) -> Option<u64> {
 }
 
 impl ::rustc_serialize::Encodable for RevocationIdType {
+
     fn encode<E: ::rustc_serialize::Encoder>(&self, e: &mut E)->Result<(), E::Error> {
         let revocation_type_tag_vec = self.type_tags.0.to_string().into_bytes();
         let id_type_tag_vec = self.type_tags.1.to_string().into_bytes();
@@ -124,9 +131,11 @@ impl ::rustc_serialize::Encodable for RevocationIdType {
                 self.public_key.0.as_ref(), self.secret_key.0.as_ref())
             ).encode(e)
     }
+
 }
 
 impl ::rustc_serialize::Decodable for RevocationIdType {
+
     fn decode<D: ::rustc_serialize::Decoder>(d: &mut D)-> Result<RevocationIdType, D::Error> {
         let _ = try!(d.read_u64());
         let (revocation_type_tag_vec, id_type_tag_vec, public_id_type_tag_vec , pub_sign_vec, sec_sign_vec):
@@ -148,6 +157,7 @@ impl ::rustc_serialize::Decodable for RevocationIdType {
                 secret_key: ::sodiumoxide::crypto::sign::SecretKey(sec_sign_arr.unwrap()),
             })
     }
+
 }
 
 #[cfg(test)]

--- a/src/id/revocation_id_type.rs
+++ b/src/id/revocation_id_type.rs
@@ -120,7 +120,7 @@ fn convert_to_u64(num_vec: Vec<u8>) -> Option<u64> {
 
 impl ::rustc_serialize::Encodable for RevocationIdType {
 
-    fn encode<E: ::rustc_serialize::Encoder>(&self, e: &mut E)->Result<(), E::Error> {
+    fn encode<E: ::rustc_serialize::Encoder>(&self, e: &mut E) -> Result<(), E::Error> {
         let revocation_type_tag_vec = self.type_tags.0.to_string().into_bytes();
         let id_type_tag_vec = self.type_tags.1.to_string().into_bytes();
         let public_id_type_tag_vec = self.type_tags.2.to_string().into_bytes();
@@ -136,7 +136,7 @@ impl ::rustc_serialize::Encodable for RevocationIdType {
 
 impl ::rustc_serialize::Decodable for RevocationIdType {
 
-    fn decode<D: ::rustc_serialize::Decoder>(d: &mut D)-> Result<RevocationIdType, D::Error> {
+    fn decode<D: ::rustc_serialize::Decoder>(d: &mut D) -> Result<RevocationIdType, D::Error> {
         let _ = try!(d.read_u64());
         let (revocation_type_tag_vec, id_type_tag_vec, public_id_type_tag_vec , pub_sign_vec, sec_sign_vec):
             (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) = try!(::rustc_serialize::Decodable::decode(d));

--- a/src/id/revocation_id_type.rs
+++ b/src/id/revocation_id_type.rs
@@ -132,11 +132,9 @@ impl ::rustc_serialize::Decodable for RevocationIdType {
             (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) = try!(::rustc_serialize::Decodable::decode(d));
         let pub_sign_arr = convert_to_array!(pub_sign_vec, ::sodiumoxide::crypto::sign::PUBLICKEYBYTES);
         let sec_sign_arr = convert_to_array!(sec_sign_vec, ::sodiumoxide::crypto::sign::SECRETKEYBYTES);
-        let (revocation_type_tag, id_type_tag, public_id_type_tag) = (
-                convert_to_u64(revocation_type_tag_vec),
-                convert_to_u64(id_type_tag_vec),
-                convert_to_u64(public_id_type_tag_vec)
-            );
+        let (revocation_type_tag, id_type_tag, public_id_type_tag) = (convert_to_u64(revocation_type_tag_vec),
+                                                                      convert_to_u64(id_type_tag_vec),
+                                                                      convert_to_u64(public_id_type_tag_vec));
 
         if pub_sign_arr.is_none() || sec_sign_arr.is_none() || revocation_type_tag.is_none() ||
             id_type_tag.is_none() ||  public_id_type_tag.is_none() {

--- a/src/id/revocation_id_type.rs
+++ b/src/id/revocation_id_type.rs
@@ -1,0 +1,217 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+/// The following key types use the internal cbor tag to identify them and this
+/// should be carried through to any json representation if stored on disk
+///
+/// RevocationIdType
+///
+/// #Examples
+/// ```
+/// // Generating public and secret keys using sodiumoxide
+/// // Create RevocationIdType
+/// let an_maid = ::maidsafe_client::id::RevocationIdType::new::<::maidsafe_client::id::MaidTypeTags>();
+/// ```
+///
+#[derive(Clone)]
+pub struct RevocationIdType {
+    type_tags: (u64, u64, u64),  // type tags for revocation, id and public ids
+    public_key: ::sodiumoxide::crypto::sign::PublicKey,
+    secret_key: ::sodiumoxide::crypto::sign::SecretKey
+}
+
+impl PartialEq for RevocationIdType {
+    fn eq(&self, other: &RevocationIdType) -> bool {
+        // Private key is mathematically linked, so just check public key
+        &self.type_tags == &other.type_tags &&
+        ::utility::slice_equal(&self.public_key.0, &other.public_key.0)
+    }
+}
+
+
+impl ::std::fmt::Debug for RevocationIdType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        let ::sodiumoxide::crypto::sign::PublicKey(ref public_key) = self.public_key;
+        write!(f, "RevocationIdType( type_tags:{:?}, public_key: {:?} )", self.type_tags, public_key)
+    }
+}
+
+impl RevocationIdType {
+    /// An instance of RevocationIdType can be created by invoking the new()
+    /// Default contructed RevocationIdType instance is returned
+    #[allow(unsafe_code)]
+    pub fn new<TypeTags>() -> RevocationIdType where TypeTags: ::id::IdTypeTags {
+        let (pub_sign_key, sec_sign_key) = ::sodiumoxide::crypto::sign::gen_keypair();
+        let type_tags: TypeTags = unsafe { ::std::mem::uninitialized() };
+        RevocationIdType {
+            type_tags: (type_tags.revocation_id_type_tag(), type_tags.id_type_tag(), type_tags.public_id_type_tag()),
+            public_key: pub_sign_key,
+            secret_key: sec_sign_key
+        }
+    }
+
+    /// Returns name
+    pub fn name(&self) -> ::routing::NameType {
+        let combined_iter = self.public_key.0.into_iter();
+        let mut combined: Vec<u8> = Vec::new();
+        for iter in combined_iter {
+            combined.push(*iter);
+        }
+        for i in self.type_tags.0.to_string().into_bytes().into_iter() {
+            combined.push(i);
+        }
+        ::routing::NameType(::sodiumoxide::crypto::hash::sha512::hash(&combined).0)
+    }
+
+    /// Returns type tags
+    pub fn type_tags(&self) -> &(u64, u64, u64) {
+        &self.type_tags
+    }
+    /// Returns type tag
+    /// TODO needless reference for built in POD
+    pub fn type_tag(&self) -> &u64 {
+        &self.type_tags.0
+    }
+    /// Returns the SecretKey of the RevocationIdType
+    pub fn secret_key(&self) -> &::sodiumoxide::crypto::sign::SecretKey {
+        &self.secret_key
+    }
+    /// Returns the PublicKey of the AnMaid
+    pub fn public_key(&self) -> &::sodiumoxide::crypto::sign::PublicKey {
+        &self.public_key
+    }
+    /// Signs the data with the SecretKey of the AnMaid and recturns the Signed Data
+    pub fn sign(&self, data : &[u8]) -> Vec<u8> {
+        return ::sodiumoxide::crypto::sign::sign(&data, &self.secret_key)
+    }
+}
+
+fn convert_to_u64(num_vec: Vec<u8>) -> Option<u64> {
+    match String::from_utf8(num_vec) {
+         Ok(string) =>  {
+             match string.parse::<u64>() {
+                 Ok(type_tag) => Some(type_tag),
+                 Err(_) => None
+             }
+         },
+         Err(_) => None
+     }
+}
+
+impl ::rustc_serialize::Encodable for RevocationIdType {
+    fn encode<E: ::rustc_serialize::Encoder>(&self, e: &mut E)->Result<(), E::Error> {
+        let revocation_type_tag_vec = self.type_tags.0.to_string().into_bytes();
+        let id_type_tag_vec = self.type_tags.1.to_string().into_bytes();
+        let public_id_type_tag_vec = self.type_tags.2.to_string().into_bytes();
+        ::cbor::CborTagEncode::new(*self.type_tag(),
+                &(revocation_type_tag_vec,
+                id_type_tag_vec,
+                public_id_type_tag_vec,
+                self.public_key.0.as_ref(), self.secret_key.0.as_ref())
+            ).encode(e)
+    }
+}
+
+impl ::rustc_serialize::Decodable for RevocationIdType {
+    fn decode<D: ::rustc_serialize::Decoder>(d: &mut D)-> Result<RevocationIdType, D::Error> {
+        let (revocation_type_tag_vec, id_type_tag_vec, public_id_type_tag_vec , pub_sign_vec, sec_sign_vec):
+            (Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>, Vec<u8>) = try!(::rustc_serialize::Decodable::decode(d));
+        let pub_sign_arr = convert_to_array!(pub_sign_vec, ::sodiumoxide::crypto::sign::PUBLICKEYBYTES);
+        let sec_sign_arr = convert_to_array!(sec_sign_vec, ::sodiumoxide::crypto::sign::SECRETKEYBYTES);
+        let (revocation_type_tag, id_type_tag, public_id_type_tag) = (
+                convert_to_u64(revocation_type_tag_vec),
+                convert_to_u64(id_type_tag_vec),
+                convert_to_u64(public_id_type_tag_vec)
+            );
+
+        if pub_sign_arr.is_none() || sec_sign_arr.is_none() || revocation_type_tag.is_none() ||
+            id_type_tag.is_none() ||  public_id_type_tag.is_none() {
+            return Err(d.error("Bad RevocationIdType size"));
+        }
+
+        Ok(RevocationIdType{ type_tags: (revocation_type_tag.unwrap(), id_type_tag.unwrap(), public_id_type_tag.unwrap()),
+             public_key: ::sodiumoxide::crypto::sign::PublicKey(pub_sign_arr.unwrap()),
+             secret_key: ::sodiumoxide::crypto::sign::SecretKey(sec_sign_arr.unwrap()) })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    extern crate rand;
+
+    use super::RevocationIdType;
+    use self::rand::Rng;
+    use ::id::Random;
+    
+    impl Random for RevocationIdType {
+        fn generate_random() -> RevocationIdType {
+            RevocationIdType::new::<::id::MaidTypeTags>()
+        }
+    }
+
+#[test]
+    fn create_an_mpid() {
+        let _ = RevocationIdType::new::<::id::MpidTypeTags>();
+    }
+
+#[test]
+    fn serialisation_an_maid() {
+        let obj_before = RevocationIdType::generate_random();
+        let mut e = ::cbor::Encoder::from_memory();
+        e.encode(&[&obj_before]).unwrap();
+
+        let mut d = ::cbor::Decoder::from_bytes(e.as_bytes());
+        match d.decode().next().unwrap().unwrap() {
+            ::data_parser::Parser::AnMaid(obj_after) => assert_eq!(obj_before, obj_after),
+            _ => panic!("Unexpected!"),
+        }
+    }
+
+#[test]
+    fn equality_assertion_an_maid() {
+        let first_obj = RevocationIdType::generate_random();
+        let second_obj = RevocationIdType::generate_random();
+        let cloned_obj = second_obj.clone();
+
+        assert!(first_obj != second_obj);
+        assert!(second_obj == cloned_obj);
+    }
+
+#[test]
+    fn generation() {
+        let maid1 = RevocationIdType::generate_random();
+        let maid2 = RevocationIdType::generate_random();
+        let maid2_clone = maid2.clone();
+
+        assert_eq!(maid2, maid2_clone);
+        assert!(!(maid2 != maid2_clone));
+        assert!(maid1 != maid2);
+
+        let random_bytes = rand::thread_rng().gen_iter::<u8>().take(100).collect::<Vec<u8>>();
+        {
+            let sign1 = maid1.sign(&random_bytes);
+            let sign2 = maid2.sign(&random_bytes);
+            assert!(sign1 != sign2);
+
+            assert!(::sodiumoxide::crypto::sign::verify(&sign1, &maid1.public_key()).is_some());
+            assert!(::sodiumoxide::crypto::sign::verify(&sign2, &maid1.public_key()).is_none());
+
+            assert!(::sodiumoxide::crypto::sign::verify(&sign2, &maid2.public_key()).is_some());
+            assert!(::sodiumoxide::crypto::sign::verify(&sign2, &maid1.public_key()).is_none());
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 
 #![deny(deprecated, improper_ctypes, missing_docs, non_shorthand_field_patterns,
 overflowing_literals, plugin_as_library, private_no_mangle_fns, private_no_mangle_statics,
-raw_pointer_derive, stable_features, unconditional_recursion, unknown_lints, unsafe_code,
+raw_pointer_derive, stable_features, unconditional_recursion, unknown_lints,
 unsigned_negation, unused, unused_allocation, unused_attributes, unused_comparisons,
 unused_features, unused_parens, while_true)]
 
@@ -51,11 +51,18 @@ extern crate sodiumoxide;
 extern crate rustc_serialize;
 extern crate maidsafe_types;
 extern crate lru_time_cache;
+
+/// Macros defined for usage
+#[macro_use]
+mod macros;
 /// Self-Auth and Gateway Module
 pub mod client;
 /// Parse incoming data
 pub mod data_parser;
-
+/// Public and Private Id types
+pub mod id;
+/// All Maidsafe tagging should offset from this
+pub const MAIDSAFE_TAG: u64 = 5483_000;
 /// Representation of input/output error
 pub type IoError = std::io::Error;
 
@@ -64,7 +71,9 @@ pub enum CryptoError {
     /// TODO
     SymmetricCryptoError(crypto::symmetriccipher::SymmetricCipherError),
     /// TODO
-    BadBuffer
+    BadBuffer,
+    /// TODO
+    Unknown,
 }
 
 impl From<crypto::symmetriccipher::SymmetricCipherError> for CryptoError {
@@ -134,5 +143,12 @@ pub mod utility {
     /// Generates a random PIN number
     pub fn generate_random_pin() -> u32 {
         ::rand::random::<u32>() % 10000
+    }
+
+    ///
+    /// Returns true if both slices are equal in length, and have equal contents
+    ///
+    pub fn slice_equal<T: PartialEq>(lhs: &[T], rhs: &[T]) -> bool {
+        lhs.len() == rhs.len() && lhs.iter().zip(rhs.iter()).all(|(a, b)| a == b)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 
 #![deny(deprecated, improper_ctypes, missing_docs, non_shorthand_field_patterns,
 overflowing_literals, plugin_as_library, private_no_mangle_fns, private_no_mangle_statics,
-raw_pointer_derive, stable_features, unconditional_recursion, unknown_lints,
+raw_pointer_derive, stable_features, unconditional_recursion, unknown_lints, unsafe_code,
 unsigned_negation, unused, unused_allocation, unused_attributes, unused_comparisons,
 unused_features, unused_parens, while_true)]
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -32,7 +32,7 @@ macro_rules! convert_to_array {
             None
         } else {
             use std::mem;
-            let mut arr : [_; $size] = unsafe { mem::uninitialized() };
+            let mut arr : [_; $size] = [0; $size];
             for element in $container.into_iter().enumerate() {
                 let old_val = mem::replace(&mut arr[element.0], element.1);
                 mem::forget(old_val);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,43 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+///
+/// Convert a container to an array. If the container is not the exact size specified, None is
+/// returned. Otherwise, all of the elements are moved into the array.
+///
+/// ```
+/// let mut data = Vec::<usize>::new();
+/// data.push(1);
+/// data.push(2);
+/// assert!(convert_to_array(data, 2).is_some());
+/// assert!(convert_to_array(data, 3).is_none());
+/// ```
+macro_rules! convert_to_array {
+    ($container:ident, $size:expr) => {{
+        if $container.len() != $size {
+            None
+        } else {
+            use std::mem;
+            let mut arr : [_; $size] = unsafe { mem::uninitialized() };
+            for element in $container.into_iter().enumerate() {
+                let old_val = mem::replace(&mut arr[element.0], element.1);
+                mem::forget(old_val);
+            }
+            Some(arr)
+        }
+    }};
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,6 +26,7 @@
 /// assert!(convert_to_array(data, 2).is_some());
 /// assert!(convert_to_array(data, 3).is_none());
 /// ```
+
 macro_rules! convert_to_array {
     ($container:ident, $size:expr) => {{
         if $container.len() != $size {


### PR DESCRIPTION
Private and public IDs moved from maidsafe_types. Had to remove unsafe_code lint check because the #[allow(unsafe_code)] wont work in macros.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/maidsafe_client/100)
<!-- Reviewable:end -->
